### PR TITLE
Switch pct exec from using /bin/sh to /bin/bash

### DIFF
--- a/lxc-exec
+++ b/lxc-exec
@@ -6,7 +6,7 @@ if [[ $1 =~ ^[0-9]*$ ]]; then
     shift
     COMMAND=$@
     echo -ne "\e[1;32mexecuting \"$COMMAND\" in container #${CONTAINER} ($(grep -m 1 hostname /etc/pve/lxc/${CONTAINER}.conf | awk '{print $NF}'))\e[0m\n"
-    pct exec $CONTAINER /bin/sh -- -c "$COMMAND"
+    pct exec $CONTAINER /bin/bash -- -c "$COMMAND"
   else
     echo -ne "\e[1;31mcontainer $1 is not running\e[0m\n"
     exit 1


### PR DESCRIPTION
Since bash supports advanced features.
Fixes the following issue: ``cannot set lc_ctype to default locale no such file or directory``